### PR TITLE
Fix README title typo to Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Git Tutorial
 
+
 <img src=img/git-meme.jpg width=300px />
 
 Git has a well-earned reputation for being hard.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git Tutrial
+# Git Tutorial
 
 <img src=img/git-meme.jpg width=300px />
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Git Tutorial
 
-
 <img src=img/git-meme.jpg width=300px />
 
 Git has a well-earned reputation for being hard.


### PR DESCRIPTION
This pull request fixes a typo in the README title by changing "Tutrial" to "Tutorial". The change was made in README.md on the fix-typo branch.