### PR TITLE
Fix typo in README title: Tutrial -> Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git Tutrial
+# Git Tutorial
 
 <img src=img/git-meme.jpg width=300px />
 


### PR DESCRIPTION
The README title contained a typo: 'Tutrial' should be 'Tutorial'. This PR fixes it.