### PR TITLE
fix typo in README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git Tutrial
+# Git Tutorial
 
 <img src=img/git-meme.jpg width=300px />
 


### PR DESCRIPTION
This request fixes the typo in the README title from 'Tutrial' to 'Tutorial'.