### PR TITLE
Fix typo: 'Tutrial' should be 'Tutorial' in page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git Tutrial
+# Git Tutorial
 
 <img src=img/git-meme.jpg width=300px />
 


### PR DESCRIPTION
Submitting a pull request to fix the intentional typo for this week's lab.